### PR TITLE
Double escape special chars in override.conf

### DIFF
--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/etc/systemd/system/meshtasticd.service.d/override.conf
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/etc/systemd/system/meshtasticd.service.d/override.conf
@@ -1,6 +1,6 @@
 [Service]
 ExecStart=
-ExecStart=/bin/sh -c '/usr/sbin/meshtasticd -h $(sed -n "/Serial/ s/^.*: \(.*\)$/\U\1/p" /proc/cpuinfo | bc | tail -c 9)'
+ExecStart=/bin/sh -c '/usr/sbin/meshtasticd -h $(sed -n "/Serial/ s/^.*: \\(.*\\)$/\\U\\1/p" /proc/cpuinfo | bc | tail -c 9)'
 Nice=-20
 
 [Unit]


### PR DESCRIPTION
To fix the error:
```
femtofox systemd[1]: /etc/systemd/system/meshtasticd.service.d/override.conf:3: Ignoring unknown escape sequences: "/usr/sbin/meshtasticd -h $(sed -n "/Serial/ s/^.*: \(.*\)$/\U\1/p" /proc/cpuinfo | bc | tail -c 9)"
```