### PR TITLE
Remove pipe serial to bc for node id in override.conf

### DIFF
--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/etc/systemd/system/meshtasticd.service.d/override.conf
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/etc/systemd/system/meshtasticd.service.d/override.conf
@@ -1,6 +1,6 @@
 [Service]
 ExecStart=
-ExecStart=/bin/sh -c '/usr/sbin/meshtasticd -h $(sed -n "/Serial/ s/^.*: \\(.*\\)$/\\U\\1/p" /proc/cpuinfo | bc | tail -c 9)'
+ExecStart=/bin/sh -c '/usr/sbin/meshtasticd -h $(sed -n "/Serial/ s/^.*: \\(.*\\)$/\\U\\1/p" /proc/cpuinfo | tail -c 9)'
 Nice=-20
 
 [Unit]


### PR DESCRIPTION
This small change to override.conf allows a node id to be more accurately based on the cpu serial number.  As you can see below, the current implementation pipes the serial into the basic calculator which cannot interpret base16.  All letters are converted to 9's.   Removing ` | bc ` allows for a greater range of unique id's by keeping the hex value and passing that to meshtasticd.

Be warned, this change will likely change the board's current node id. 

```shell
femto@femtofox:~$ sed -n "/Serial/ s/^.*: \(.*\)$/\U\1/p" /proc/cpuinfo
EC75F48C596AB32E
femto@femtofox:~$ sed -n "/Serial/ s/^.*: \(.*\)$/\U\1/p" /proc/cpuinfo | tail -c 9
596AB32E
femto@femtofox:~$ sed -n "/Serial/ s/^.*: \(.*\)$/\U\1/p" /proc/cpuinfo | bc | tail -c -9
59699329
```
