### PR TITLE
Fixed compiler.  Removed apt cleanout from build.

### DIFF
--- a/environment-setup/femtofox.chroot
+++ b/environment-setup/femtofox.chroot
@@ -37,6 +37,17 @@ DEBIAN_FRONTEND=noninteractive apt install -y --option Dpkg::Options::="--force-
 #DEBIAN_FRONTEND=noninteractive apt install -y --option Dpkg::Options::="--force-confold" ./meshtasticd_2.5.11.8e2a3e5_armhf.deb
 #rm ./meshtasticd_2.5.11.8e2a3e5_armhf.deb
 
+# Ensure libgcc_s.so and libc_nonshared.a exist
+mkdir -p /usr/lib/gcc/arm-linux-gnueabihf/11/
+ln -sf /usr/lib/arm-linux-gnueabihf/libgcc_s.so.1 /usr/lib/gcc/arm-linux-gnueabihf/11/libgcc_s.so
+ln -sf /usr/lib/arm-linux-gnueabihf/libgcc_s.so.1 /lib/libgcc_s.so.1
+ln -sf /usr/lib/gcc/arm-linux-gnueabihf/11/libgcc_s.so /usr/lib/libgcc.so
+
+# Add library paths
+echo "/usr/lib/gcc/arm-linux-gnueabihf/11" | tee -a /etc/ld.so.conf.d/gcc.conf
+ldconfig
+
+
 echo "Installing dependencies for meshing-around and meshtastic cli..."
 #pip config set global.extra-index-url https://www.piwheels.org/simple
 pip3 install requests pyephem pytap2 meshtastic pypubsub geopy maidenhead beautifulsoup4 dadjokes schedule wikipedia googlesearch-python
@@ -56,13 +67,13 @@ echo "femtofox" | tee /etc/hostname > /dev/null
 
 echo "Configuring autostart of systemd services..."
 systemctl enable button
-systemctl enable meshtasticd
 systemctl enable femto-runonce.service
 systemctl enable femto-usb-config-tool.service
 systemctl enable femto-boot-complete.service
 systemctl enable femto-wifi-mesh-control
 systemctl enable femto-watchclock-dog
 
+systemctl disable meshtasticd
 systemctl disable apt-daily.timer
 systemctl disable unattended-upgrades
 systemctl disable smbd nmbd # samba services, can be enabled via menu
@@ -101,5 +112,6 @@ usermod -a -G tty femto
 usermod -a -G dialout femto
 
 echo "Cleaning up chroot..."
-apt clean && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/* && rm -rf /var/tmp/* && find /var/log -type f -exec truncate -s 0 {} + && : > /root/.bash_history && history -c
+rm -rf /tmp/* && rm -rf /var/tmp/* && find /var/log -type f -exec truncate -s 0 {} + && : > /root/.bash_history && history -c
+
 exit

--- a/environment-setup/femtofox.chroot
+++ b/environment-setup/femtofox.chroot
@@ -37,17 +37,6 @@ DEBIAN_FRONTEND=noninteractive apt install -y --option Dpkg::Options::="--force-
 #DEBIAN_FRONTEND=noninteractive apt install -y --option Dpkg::Options::="--force-confold" ./meshtasticd_2.5.11.8e2a3e5_armhf.deb
 #rm ./meshtasticd_2.5.11.8e2a3e5_armhf.deb
 
-# Ensure libgcc_s.so and libc_nonshared.a exist
-mkdir -p /usr/lib/gcc/arm-linux-gnueabihf/11/
-ln -sf /usr/lib/arm-linux-gnueabihf/libgcc_s.so.1 /usr/lib/gcc/arm-linux-gnueabihf/11/libgcc_s.so
-ln -sf /usr/lib/arm-linux-gnueabihf/libgcc_s.so.1 /lib/libgcc_s.so.1
-ln -sf /usr/lib/gcc/arm-linux-gnueabihf/11/libgcc_s.so /usr/lib/libgcc.so
-
-# Add library paths
-echo "/usr/lib/gcc/arm-linux-gnueabihf/11" | tee -a /etc/ld.so.conf.d/gcc.conf
-ldconfig
-
-
 echo "Installing dependencies for meshing-around and meshtastic cli..."
 #pip config set global.extra-index-url https://www.piwheels.org/simple
 pip3 install requests pyephem pytap2 meshtastic pypubsub geopy maidenhead beautifulsoup4 dadjokes schedule wikipedia googlesearch-python
@@ -110,6 +99,19 @@ echo 'femto:femto' | chpasswd
 sudo chage -d 0 femto
 usermod -a -G tty femto
 usermod -a -G dialout femto
+
+# Ensure libgcc_s.so and libc_nonshared.a exist
+mkdir -p /usr/lib/gcc/arm-linux-gnueabihf/11/
+ln -sf /usr/lib/arm-linux-gnueabihf/libgcc_s.so.1 /usr/lib/gcc/arm-linux-gnueabihf/11/libgcc_s.so
+ln -sf /usr/lib/arm-linux-gnueabihf/libgcc_s.so.1 /lib/libgcc_s.so.1
+ln -sf /usr/lib/gcc/arm-linux-gnueabihf/11/libgcc_s.so /usr/lib/libgcc.so
+
+# Add library paths
+echo "/usr/lib/gcc/arm-linux-gnueabihf/11" | tee -a /etc/ld.so.conf.d/gcc.conf
+ldconfig
+
+# Back up libc_nonshared.a because build.sh removes it
+cp /usr/lib/arm-linux-gnueabihf/libc_nonshared.a /usr/lib/arm-linux-gnueabihf/libc_nonshared.a.keep
 
 echo "Cleaning up chroot..."
 rm -rf /tmp/* && rm -rf /var/tmp/* && find /var/log -type f -exec truncate -s 0 {} + && : > /root/.bash_history && history -c

--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-runonce.sh
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-runonce.sh
@@ -22,6 +22,7 @@ Re-running this script will:\n\
 * Set the eth0 MAC to be derivative of CPU serial number\n\
 * Add terminal type to user femto's .bashrc\n\
 * Add a shortcut \`sfc\` to user femto's .bashrc\n\
+* Enable the meshtasticd service\n\
 \n\
 Finally, the Femtofox will reboot.\n\
 \n\
@@ -98,6 +99,10 @@ else
   log_message "TERM, LANG and NCURSES_NO_UTF8_ACS already present in .bashrc, skipping"
 fi
 
+# Fix Compiler
+log_message "Fixing Compiler."
+cp /usr/lib/arm-linux-gnueabihf/libc_nonshared.a.keep /usr/lib/arm-linux-gnueabihf/libc_nonshared.a
+
 # Add a cheeky alias to .bash_aliases
 if ! grep -Fxq "alias sfc='sudo femto-config'" /home/femto/.bashrc; then # Check if the lines are already in .bash_aliases
   echo "alias sfc='sudo femto-config'" >> /home/femto/.bashrc
@@ -105,6 +110,9 @@ if ! grep -Fxq "alias sfc='sudo femto-config'" /home/femto/.bashrc; then # Check
 else
   log_message "\`alias sfc='sudo femto-config'\` already present in .bashrc, skipping"
 fi
+
+log_message "Enabling meshtasticd service"
+systemctl enable meshtasticd
 
 # remove first boot flag
 sed -i -E 's/^first_boot=.*/first_boot=false/' /etc/femto.conf


### PR DESCRIPTION
build.sh was removing compiler pieces we needed when building the image.
Because foxbuntu is mostly a wrapper and drop-ins for luckfox-sdk, instead of changing build.sh behavior I worked around it.

To test:
echo 'int main() { return 0; }' > test.c
gcc -v test.c -o test

Also, the luckfox pico struggles with apt updates so I left the initial lists and cache in the image.
May help a little the first time.