### PR TITLE
wrong arg in getting private key in femto-config

### DIFF
--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-config
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-config
@@ -560,7 +560,7 @@ meshtastic_settings() {
               ;;
               2) # view/change private key)
                 loading "Getting current private key..."
-                key=$(femto-meshtasticd-config.sh -u)
+                key=$(femto-meshtasticd-config.sh -r)
                 if [ -n "$key" ]; then
                   dialog --no-collapse --title "Meshtastic private key" --yesno "Current private key:\n$key\n\nSet new key?" 9 55
                   if [ $? -eq 0 ]; then #unless cancel/no


### PR DESCRIPTION
Just a typo in the menu:  was -u and should have been -r
Nice catch @NomDeTom 