### PR TITLE
Default routes auto update more reliably (thanks @Ruledo)

### DIFF
--- a/environment-setup/femtofox.chroot
+++ b/environment-setup/femtofox.chroot
@@ -62,7 +62,8 @@ systemctl enable femto-boot-complete.service
 systemctl enable femto-wifi-mesh-control
 systemctl enable femto-watchclock-dog
 
-systemctl disable meshtasticd
+systemctl disable ttyd   # enabled on first boot
+systemctl disable meshtasticd   # enabled on first boot
 systemctl disable apt-daily.timer
 systemctl disable unattended-upgrades
 systemctl disable smbd nmbd # samba services, can be enabled via menu

--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/etc/network/interfaces
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/etc/network/interfaces
@@ -8,4 +8,13 @@ iface lo inet loopback
 allow-hotplug wlan0
 iface wlan0 inet dhcp
     wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
+    metric 100
+    post-up sleep 5 && dhclient wlan0
+    pre-down ip route del default via $(ip route | awk '/default/ {print $3}') dev wlan0 metric 100
 
+
+allow-hotplug eth0
+iface eth0 inet dhcp
+    metric 10
+    post-up ip route replace default via $(ip route | awk '/default/ {print $3}') dev eth0 metric 10
+    pre-down ip route del default via $(ip route | awk '/default/ {print $3}') dev eth0 metric 10

--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-runonce.sh
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-runonce.sh
@@ -115,6 +115,7 @@ femto-utils.sh -E
 #generate ttyd SSL keys
 log_message "Generating new Web Terminal (ttyd) SSL encryption keys. This can take a couple minutes..."
 /usr/local/bin/packages/ttyd.sh -k
+systemctl enable ttyd
 
 # remove first boot flag
 systemctl disable femto-runonce

--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-runonce.sh
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-runonce.sh
@@ -70,16 +70,16 @@ fi
 
 # prevent randomized mac address for eth0. If `eth0`` is already present in /etc/network/interfaces, skip
 mac="$(awk '/Serial/ {print $3}' /proc/cpuinfo | tail -c 11 | sed 's/^\(.*\)/a2\1/' | sed 's/\(..\)/\1:/g;s/:$//')"
-if ! grep -q "eth0" /etc/network/interfaces; then
+file="/etc/network/interfaces"
+if ! grep -q "    hwaddress ether $mac" "$file"; then
   log_message "Setting eth0 MAC address to $mac (derivative of CPU s/n)"
-  cat <<EOF >> /etc/network/interfaces
-# static mac address for onboard ethernet (castellated pins)
-allow-hotplug eth0
-iface eth0 inet dhcp
-hwaddress ether $mac
-EOF
+  awk -v mac="$mac" '
+    { print }
+    /allow-hotplug eth0/ { count=5 }
+    count && --count == 0 { print "    hwaddress ether " mac }
+  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
 else
-  log_message "eth0 already exists in /etc/network/interfaces, skipping"
+  log_message "eth0 mac address already set in /etc/network/interfaces, skipping"
 fi
 
 # Add term stuff to .bashrc

--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-runonce.sh
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-runonce.sh
@@ -115,6 +115,7 @@ femto-utils.sh -E
 #generate ttyd SSL keys
 log_message "Generating new Web Terminal (ttyd) SSL encryption keys. This can take a couple minutes..."
 /usr/local/bin/packages/ttyd.sh -k
+log_message "Enabling Web Terminal (ttyd) service...
 systemctl enable ttyd
 
 # remove first boot flag

--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-runonce.sh
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/usr/local/bin/femto-runonce.sh
@@ -110,7 +110,7 @@ systemctl enable meshtasticd
 
 #generate SSH keys
 log_message "Generating new SSH encryption keys. This can take a couple minutes..."
-#femto-utils.sh -E
+femto-utils.sh -E
 
 #generate ttyd SSL keys
 log_message "Generating new Web Terminal (ttyd) SSL encryption keys. This can take a couple minutes..."


### PR DESCRIPTION
Added some small optimizations to this PR from @Ruledo 
Closes #354 

From @Ruledo:
Modified /etc/network/interfaces (and run once script) so that default routes update better.
This came up when unplugging and replugging eth0 and or wlan0.
So far every real-time combo I have tried is working well.