### PR TITLE
improve apt performance

### DIFF
--- a/environment-setup/femtofox.chroot
+++ b/environment-setup/femtofox.chroot
@@ -1,6 +1,12 @@
 echo "Inside chroot environment..."
 echo "tmpfs /run tmpfs rw,nodev,nosuid,size=32M 0 0" | tee -a /etc/fstab
 
+echo "Tuning apt for low memory usage..."
+# disable unused repositories to allow apt operations to fit in available RAM
+sed 's/^[^#]*\(universe\|multiverse\|backports\)/# &/' -i /etc/apt/sources.list
+# tune starting cache memory allocation down from 20M to 5M
+echo 'APT::Cache-Start "5242880";' > /etc/apt/apt.conf.d/00-cache
+
 # Temporarily removed for SEGFAULT fix done after upgrade below.
 #echo "Installing Meshtastic..."
 


### PR DESCRIPTION
This disables unnecessary apt repositories and tunes down starting apt cache size to reduce memory consumption and avoid swapping.

I confirmed I could do a chroot rebuild with this change and that I can see the updated files when mounting the rootfs.  It doesn't seem to impact any packages that are being installed right now.

Before:
```
femto@femtofox:~$ time sudo apt update
Hit:1 http://ports.ubuntu.com/ubuntu-ports jammy InRelease
Hit:2 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease
Get:3 http://ports.ubuntu.com/ubuntu-ports jammy-backports InRelease [127 kB]
Hit:4 https://ppa.launchpadcontent.net/meshtastic/beta/ubuntu jammy InRelease
Hit:5 http://ports.ubuntu.com/ubuntu-ports jammy-security InRelease
Get:6 http://ports.ubuntu.com/ubuntu-ports jammy/universe armhf Packages [13.5 MB]
Get:7 http://ports.ubuntu.com/ubuntu-ports jammy/universe Translation-en [5652 kB]
Get:8 http://ports.ubuntu.com/ubuntu-ports jammy/multiverse armhf Packages [164 kB]
Get:9 http://ports.ubuntu.com/ubuntu-ports jammy/multiverse Translation-en [112 kB]
Get:10 http://ports.ubuntu.com/ubuntu-ports jammy-updates/universe armhf Packages [931 kB]
Get:11 http://ports.ubuntu.com/ubuntu-ports jammy-updates/universe Translation-en [296 kB]
Get:12 http://ports.ubuntu.com/ubuntu-ports jammy-updates/multiverse armhf Packages [5188 B]
Get:13 http://ports.ubuntu.com/ubuntu-ports jammy-updates/multiverse Translation-en [11.8 kB]
Get:14 http://ports.ubuntu.com/ubuntu-ports jammy-backports/main armhf Packages [68.0 kB]
Get:15 http://ports.ubuntu.com/ubuntu-ports jammy-backports/main Translation-en [11.1 kB]
Get:16 http://ports.ubuntu.com/ubuntu-ports jammy-backports/universe armhf Packages [28.4 kB]
Get:17 http://ports.ubuntu.com/ubuntu-ports jammy-backports/universe Translation-en [16.6 kB]
Get:18 http://ports.ubuntu.com/ubuntu-ports jammy-security/universe armhf Packages [713 kB]
Get:19 http://ports.ubuntu.com/ubuntu-ports jammy-security/universe Translation-en [209 kB]
Get:20 http://ports.ubuntu.com/ubuntu-ports jammy-security/multiverse armhf Packages [2240 B]
Get:21 http://ports.ubuntu.com/ubuntu-ports jammy-security/multiverse Translation-en [8716 B]
Fetched 21.9 MB in 37s (590 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
6 packages can be upgraded. Run 'apt list --upgradable' to see them.

real	3m24.192s
user	0m0.055s
sys	0m0.175s
```

After:
```
femto@femtofox:~$ time sudo apt update
Hit:1 http://ports.ubuntu.com/ubuntu-ports jammy InRelease
Hit:2 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease
Hit:3 http://ports.ubuntu.com/ubuntu-ports jammy-security InRelease
Hit:4 https://ppa.launchpadcontent.net/meshtastic/beta/ubuntu jammy InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
4 packages can be upgraded. Run 'apt list --upgradable' to see them.

real	0m11.711s
user	0m0.047s
sys	0m0.045s
```

I was able to do a full system upgrade in 3m24s with the change as well.